### PR TITLE
chore: prepare packages for crates.io publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ version = "0.1.0"
 edition = "2024"
 authors = ["Radical Team"]
 license = "Apache-2.0"
-repository = "https://github.com/termtui/termtui"
+repository = "https://github.com/microsandbox/termtui"
+homepage = "https://github.com/microsandbox/termtui"
+documentation = "https://docs.rs/termtui"
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/termtui-macros/Cargo.toml
+++ b/termtui-macros/Cargo.toml
@@ -4,6 +4,12 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/termtui-macros"
+description = "Procedural macros for the termtui terminal UI framework"
+keywords = ["tui", "terminal", "macro", "proc-macro"]
+categories = ["command-line-interface"]
 
 [lib]
 proc-macro = true

--- a/termtui/Cargo.toml
+++ b/termtui/Cargo.toml
@@ -4,14 +4,19 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
 description = "A framework for building beautiful, responsive terminal user interfaces with a DOM-style hierarchical approach"
+keywords = ["tui", "terminal", "ui", "reactive", "component"]
+categories = ["command-line-interface", "gui"]
 
 [lib]
 name = "termtui"
 path = "lib/lib.rs"
 
 [dependencies]
-termtui-macros = { path = "../termtui-macros" }
+termtui-macros = { version = "0.1.0", path = "../termtui-macros" }
 bitflags = "2.4"
 crossterm = "0.28"
 serde.workspace = true


### PR DESCRIPTION
## Description

This PR adds the necessary metadata to both termtui and termtui-macros packages to enable publishing to crates.io.

### Changes Made

**Workspace Configuration (`Cargo.toml`)**
- Added repository URL pointing to `https://github.com/microsandbox/termtui`
- Added homepage URL for project discovery
- Added documentation URL for docs.rs integration

**termtui Package (`termtui/Cargo.toml`)**
- Added workspace-inherited repository, homepage, and documentation URLs
- Added keywords: `tui`, `terminal`, `ui`, `reactive`, `component` for better discoverability
- Added categories: `command-line-interface`, `gui` for crates.io categorization
- Updated termtui-macros dependency to include version `0.1.0` alongside path

**termtui-macros Package (`termtui-macros/Cargo.toml`)**
- Added workspace-inherited repository and homepage URLs
- Added documentation URL for docs.rs
- Added description: "Procedural macros for the termtui terminal UI framework"
- Added keywords: `tui`, `terminal`, `macro`, `proc-macro`
- Added category: `command-line-interface`

### Publishing Status

Both packages have been successfully published to crates.io:
- termtui-macros v0.1.0: https://crates.io/crates/termtui-macros
- termtui v0.1.0: https://crates.io/crates/termtui

### Documentation

Documentation will be automatically available at:
- https://docs.rs/termtui
- https://docs.rs/termtui-macros